### PR TITLE
SC-1903 Add Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^7.2.0|^8.0",
         "bacon/bacon-qr-code": "^2.0|^3.0",
-        "illuminate/contracts": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "pragmarx/google2fa": "^7.0|^8.0|^9.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- Extends the stickee/laravel-2fa v1.0.9 Illuminate contracts constraint to include Laravel 13.

## Verification
- Installed successfully in the Laravel 13 comparison-platform integration through Sail.
- Focused package discovery/configuration/route coverage passed.
- Full comparison-platform suite passed: 79 tests, 343 assertions.